### PR TITLE
Update ed25519.js

### DIFF
--- a/lib/ed25519.js
+++ b/lib/ed25519.js
@@ -1,13 +1,23 @@
 var nacl = require('tweetnacl');
 
+function bufferToUint8Array(buffer) {
+  return new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength / Uint8Array.BYTES_PER_ELEMENT);
+}
+
 exports.Sign = function (message, privateKey) {
-  return Buffer.from(nacl.sign.detached(message, privateKey))
+  const msg = bufferToUint8Array((message))
+  const privKey = bufferToUint8Array((privateKey))
+  return Buffer.from(nacl.sign.detached(msg, privKey))
 }
 
 exports.Verify = function (message, signature, publicKey) {
-  return nacl.sign.detached.verify(message, signature, publicKey)
+  const msg = bufferToUint8Array((message))
+  const sig = bufferToUint8Array((signature))
+  const privKey = bufferToUint8Array((publicKey))
+  return nacl.sign.detached.verify(msg, sig, privKey)
 }
 
 exports.ToPublic = function(privateKey) {
-  return nacl.sign.keyPair.fromSecretKey(privateKey).publicKey
+  const privKey = bufferToUint8Array((privateKey))
+  return nacl.sign.keyPair.fromSecretKey(privKey).publicKey
 }


### PR DESCRIPTION
When working with this lib in TypeScript project, there is an error (new TypeError('unexpected type, use Uint8Array')) thrown by `checkArrayTypes` when passing buffers to `tweetncal` .
A quick and dirty solution is proposed here.

Maybe a better solution would be to directly replace `toBuffer` functions in `ed25519Utils.js` but i'm not sure if these functions are only used to pass arguments to `tweetnacl`. 
Any thoughts ?